### PR TITLE
fix: Active cooler can only touch active cooler of the same type

### DIFF
--- a/Fission.h
+++ b/Fission.h
@@ -49,7 +49,7 @@ namespace Fission {
   class Evaluator {
     const Settings &settings;
     xt::xtensor<int, 3> mults, rules;
-    xt::xtensor<bool, 3> isActive, isModeratorInLine, visited;
+    xt::xtensor<bool, 3> isActive, isModeratorInLine, visited, accessible;
     const xt::xtensor<int, 3> *state;
     int compatibleTile;
 
@@ -63,6 +63,7 @@ namespace Fission {
     int countNeighbors(int tile, int x, int y, int z) const;
     int countCasingNeighbors(int x, int y, int z) const;
     bool checkAccessibility(int compatibleTile, int x, int y, int z);
+    bool checkCompatible(int compatibleTile, int x, int y, int z);
     bool checkAccessibility(int x, int y, int z);
   public:
     Evaluator(const Settings &settings);


### PR DESCRIPTION
Added an additional check for active cooler that should only touch other active cooler of the same type, otherwise it's an invalid placement.

Also added a slight optimization to the accessibility check which reduces the amount of checks done and slightly increase the algorithm speed and efficiency.

I was able to compile and run locally a 10x10x10 reactor that does not have the issue anymore.

Fixes #5 